### PR TITLE
Add "Copy to clipboard" button for CSS result

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,8 @@
       <!-- 4 -->
       <h2><b style="color: green; border-color: green">4</b> Result</h2>
       <pre id="result-css"></pre>
+      <button id="copy">Copy to clipboard</button>
+      <span id="copy-feedback" role="status"></span>
 
       <!-- 5 -->
       <h2>

--- a/src/main.ts
+++ b/src/main.ts
@@ -202,13 +202,18 @@ function getCSSResult(): ResultCSS {
   return res;
 }
 
-function updateCSSResult() {
+function getCSSFontFaceBlock() {
   const css = getCSSResult();
   let cssString = '@font-face {\n';
   Object.entries(css).forEach(([key, value]) => {
     cssString += `  ${key}: ${value};\n`;
   });
   cssString += '}';
+  return cssString;
+}
+
+function updateCSSResult() {
+  const cssString = getCSSFontFaceBlock();
   (document.getElementById('result-css') as HTMLPreElement).textContent =
     cssString;
 
@@ -327,6 +332,21 @@ document
       updateCSSResult();
     }
   });
+
+document.getElementById('copy')?.addEventListener('click', () => {
+  const cssString = getCSSFontFaceBlock();
+  navigator.clipboard.writeText(cssString);
+
+  // Show a feedback message to make it clear that something happened
+  const feedback = document.getElementById('copy-feedback');
+  if (!feedback) {
+    return;
+  }
+  feedback.textContent = 'Copied!';
+  setTimeout(() => {
+    feedback.textContent = '';
+  }, 5000);
+});
 
 document.getElementById('overlap')?.addEventListener('click', () => {
   const ele = document.querySelector('#test-fallback div') as HTMLDivElement;


### PR DESCRIPTION
Thanks for a great tool!

Selecting a code block to copy tends to be challenging for users that don't use a pointer device. A button to copy the code directly helps that use case, as well as being a convenient shortcut for everyone else.