### PR TITLE
Decrease precision for breaking loop

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,9 +146,10 @@ async function adjustFallbackAscent() {
     return element.getBoundingClientRect().height;
   }
 
+  const webfontHeight = Math.round(getHeight(webfontDiv));
+  
   while (maxIterations-- > 0) {
-    const webfontHeight = getHeight(webfontDiv);
-    const fallbackHeight = getHeight(fallbackDiv);
+    const fallbackHeight = Math.round(getHeight(fallbackDiv));
     if (webfontHeight === fallbackHeight) {
       console.log(`Matching ascent-override found: ${ascentOverride}%`);
       state.fontMeta['ascent-override'] = ascentOverride;


### PR DESCRIPTION
Sorry - hope you don't think I'm bombarding you with PRs too much 😅 I have a few more changes I'm thinking about, but I'll chill out for now and let you deal with these at your own pace. And please let me know if you'd like me to handle contributions in some other way than just chucking them your way.

In my testing, the fallback div's height tended to have a very high precision while being adjusted. This meant it very rarely ended up exactly matching the webfont div's height and just kept looping and adjusting the ascent-override back and forth until the max iterations were reached, even though the result looked correct to the human eye. By rounding the heights, we might technically decrease the precision slightly, but in favour of doing less unnecessary work.

I also moved the height check for the webfont div outside of the loop since that height doesn't seem to change during the loop. I haven't measured or anything, but `getBoundingClientRect()` calls are often expensive.